### PR TITLE
Feature/문제 2 화면 구현

### DIFF
--- a/ProjectVision/ProjectVision/Source/RoomTwo/Model/RoomTwoQuestion.swift
+++ b/ProjectVision/ProjectVision/Source/RoomTwo/Model/RoomTwoQuestion.swift
@@ -1,0 +1,27 @@
+//
+//  RoomTwoQuestion.swift
+//  ProjectVision
+//
+//  Created by minsong kim on 3/25/25.
+//
+
+enum RoomTwoQuestion {
+    case first
+
+    // MARK: - Computed Properties
+
+    var description: String {
+        switch self {
+        case .first:
+            """
+            강의실에서 수업을 한 귀로 듣고 한 귀로 흘리고 있는데,
+            지난 번에 공간을 열 수 있는 답을 적어주었던 친구와 눈이 마주쳤다.
+
+            아, 어떻게든 저 친구를 우리 동아리에 데려와야 하는데!
+            일단 반갑게 인사를 해야겠다.
+
+            단, 수업 중이니 입모양으로만 전달해보자.
+            """
+        }
+    }
+}

--- a/ProjectVision/ProjectVision/Source/RoomTwo/View/RoomTwoView.swift
+++ b/ProjectVision/ProjectVision/Source/RoomTwo/View/RoomTwoView.swift
@@ -1,0 +1,36 @@
+//
+//  RoomTwoView.swift
+//  ProjectVision
+//
+//  Created by minsong kim on 3/25/25.
+//
+
+import SwiftUI
+
+struct RoomTwoView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Text("문제 2.")
+                    .font(.largeTitle)
+                    .bold()
+                Spacer()
+            }
+            Text(RoomTwoQuestion.first.description)
+                .lineSpacing(4)
+            Button("인사하러 가기") { }
+                .bold()
+                .padding()
+                .foregroundStyle(.white)
+                .background {
+                    RoundedRectangle(cornerRadius: 16)
+                        .foregroundStyle(.blue)
+                }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    RoomTwoView()
+}


### PR DESCRIPTION
close #5 

## 📝 요약(Summary)
- 문제 2 화면을 구현했습니다.

## 📸스크린샷 (선택)
| 스크린샷 |
| -- |
|<img src="https://github.com/user-attachments/assets/b2748e37-adbc-4d30-95b2-603fc50c8515" width=300>|

## 💬 공유사항 to 리뷰어
- 문제 길이가 짧아서 Spacer를 사용해서 위로 올리진 않고 가운데에 정렬되게 두었습니다.
- 행간이 너무 가까운 것 같아, lineSpacing으로 행간을 조절했습니다.
